### PR TITLE
Start redis container without persistence

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
       - 6379:6379
     volumes:
       - ./fixtures/redis:/data
+    command: redis-server --save "" --appendonly no
   exporter:
     build: .
     ports:


### PR DESCRIPTION
If persistence is enabled redis saves data and modifies dump.rdb file. This is not necessary for this.

@vinted/sre-foundations 