### PR TITLE
Add golangci-lint config and github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,16 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.21'
       - uses: actions/checkout@v3
       - run: go test -v ./...
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+issues:
+  exclude:
+    - "Error return value of `\\(github.com/go-kit/log.Logger\\).Log` is not checked"

--- a/cmd/sonic-exporter/main.go
+++ b/cmd/sonic-exporter/main.go
@@ -34,13 +34,16 @@ func main() {
 
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`<html>
+		_, err := w.Write([]byte(`<html>
              <head><title>Sonic Exporter</title></head>
              <body>
              <h1>Sonic Exporter</h1>
              <p><a href='` + *metricsPath + `'>Metrics</a></p>
              </body>
              </html>`))
+		if err != nil {
+			level.Error(logger).Log("msg", "Error writing response")
+		}
 	})
 	srv := &http.Server{}
 	if err := web.ListenAndServe(srv, webConfig, logger); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vinted/sonic-exporter
 
-go 1.19
+go 1.21
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.3.2


### PR DESCRIPTION
Add golangci-lint integration. Changes:
- bump golang version to 1.21
- add exclude for linter to not fail if Log error check is skipped
- fix an issue where w.Write error is not checked.

@vinted/sre-foundations 