### PR TITLE
Bump builder container golang to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ===========
 # Build stage
 # ===========
-FROM golang:1.19.12-alpine3.18 AS builder
+FROM golang:1.21.0-alpine3.18 AS builder
 
 WORKDIR /code
 


### PR DESCRIPTION
Bump to a newer builder container with golang 1.21.

@vinted/sre-foundations 