### PR TITLE
Add CRM collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Prometheus exporter for [SONiC](https://github.com/sonic-net/SONiC) NOS.
 Currently supported collectors:
 - [HW collector](internal/collector/hw_collector.go): collects metrics about PSU and Fan operation
 - [Interface collector](internal/collector/interface_collector.go): collect metrics about interface operation and performance.
+- [CRM collector](internal/collector/hw_collector.go): collects Critial Resource Monitoring metrics.
 
 # Usage
 

--- a/cmd/sonic-exporter/main.go
+++ b/cmd/sonic-exporter/main.go
@@ -31,8 +31,10 @@ func main() {
 
 	interfaceCollector := collector.NewInterfaceCollector(logger)
 	hwCollector := collector.NewHwCollector(logger)
+	crmCollector := collector.NewCrmCollector(logger)
 	prometheus.MustRegister(interfaceCollector)
 	prometheus.MustRegister(hwCollector)
+	prometheus.MustRegister(crmCollector)
 
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/fixtures/test/counters_db_data.json
+++ b/fixtures/test/counters_db_data.json
@@ -154,6 +154,32 @@
       "SAI_PORT_STAT_PAUSE_TX_PKTS": "2",
       "SAI_PORT_STAT_IF_IN_OCTETS": "123",
       "SAI_PORT_STAT_IF_OUT_OCTETS": "452"
+    },
+    "CRM:STATS": {
+      "crm_stats_dnat_entry_used": "0",
+      "crm_stats_fdb_entry_used": "5",
+      "crm_stats_ipmc_entry_used": "0",
+      "crm_stats_ipv4_neighbor_used": "18",
+      "crm_stats_ipv4_nexthop_used": "18",
+      "crm_stats_ipv4_route_used": "1610",
+      "crm_stats_ipv6_neighbor_used": "8",
+      "crm_stats_ipv6_nexthop_used": "8",
+      "crm_stats_ipv6_route_used": "3",
+      "crm_stats_nexthop_group_member_used": "3",
+      "crm_stats_nexthop_group_used": "1",
+      "crm_stats_snat_entry_used": "0",
+      "crm_stats_dnat_entry_available": "1023",
+      "crm_stats_fdb_entry_available": "65530",
+      "crm_stats_ipmc_entry_available": "24576",
+      "crm_stats_ipv4_neighbor_available": "49130",
+      "crm_stats_ipv4_nexthop_available": "65460",
+      "crm_stats_ipv4_route_available": "80299",
+      "crm_stats_ipv6_neighbor_available": "24565",
+      "crm_stats_ipv6_nexthop_available": "65460",
+      "crm_stats_ipv6_route_available": "32765",
+      "crm_stats_nexthop_group_available": "511",
+      "crm_stats_nexthop_group_member_available": "32765",
+      "crm_stats_snat_entry_available": "1023"
     }
   }
 }

--- a/internal/collector/crm_collector.go
+++ b/internal/collector/crm_collector.go
@@ -93,6 +93,8 @@ func (collector *crmCollector) scrapeMetrics(ctx context.Context) error {
 		return fmt.Errorf("redis client initialization failed: %w", err)
 	}
 
+	defer redisClient.Close()
+
 	// Reset metrics
 	collector.cachedMetrics = []prometheus.Metric{}
 

--- a/internal/collector/crm_collector.go
+++ b/internal/collector/crm_collector.go
@@ -1,0 +1,140 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/vinted/sonic-exporter/pkg/redis"
+)
+
+type crmCollector struct {
+	crmResourceAvailable   *prometheus.Desc
+	crmResourceUsed        *prometheus.Desc
+	scrapeDuration         *prometheus.Desc
+	scrapeCollectorSuccess *prometheus.Desc
+	cachedMetrics          []prometheus.Metric
+	lastScrapeTime         time.Time
+	logger                 log.Logger
+	mu                     sync.Mutex
+}
+
+func NewCrmCollector(logger log.Logger) *crmCollector {
+	const (
+		namespace = "sonic"
+		subsystem = "crm"
+	)
+
+	return &crmCollector{
+		crmResourceAvailable: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "crm_resource_available"),
+			"Maximum available value for a resource", []string{"resource"}, nil),
+		crmResourceUsed: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "crm_resource_used"),
+			"Used value for a resource", []string{"resource"}, nil),
+		scrapeDuration: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "scrape_duration_seconds"),
+			"Time it took for prometheus to scrape sonic crm metrics", nil, nil),
+		scrapeCollectorSuccess: prometheus.NewDesc(prometheus.BuildFQName(namespace, subsystem, "collector_success"),
+			"Whether crm collector succeeded", nil, nil),
+		logger: logger,
+	}
+}
+
+func (collector *crmCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- collector.crmResourceAvailable
+	ch <- collector.crmResourceUsed
+	ch <- collector.scrapeDuration
+	ch <- collector.scrapeCollectorSuccess
+}
+
+func (collector *crmCollector) Collect(ch chan<- prometheus.Metric) {
+	const cacheDuration = 15 * time.Second
+
+	scrapeSuccess := 1.0
+
+	var ctx = context.Background()
+
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+
+	if time.Since(collector.lastScrapeTime) < cacheDuration {
+		// Return cached metrics without making redis calls
+		level.Info(collector.logger).Log("msg", "Returning crm metrics from cache")
+
+		for _, metric := range collector.cachedMetrics {
+			ch <- metric
+		}
+		return
+	}
+
+	err := collector.scrapeMetrics(ctx)
+	if err != nil {
+		scrapeSuccess = 0
+		level.Error(collector.logger).Log("err", err)
+	}
+	collector.cachedMetrics = append(collector.cachedMetrics, prometheus.MustNewConstMetric(
+		collector.scrapeCollectorSuccess, prometheus.GaugeValue, scrapeSuccess,
+	))
+
+	for _, cachedMetric := range collector.cachedMetrics {
+		ch <- cachedMetric
+	}
+}
+
+func (collector *crmCollector) scrapeMetrics(ctx context.Context) error {
+	level.Info(collector.logger).Log("msg", "Starting crm metric scrape")
+	scrapeTime := time.Now()
+
+	redisClient, err := redis.NewClient()
+	if err != nil {
+		return fmt.Errorf("redis client initialization failed: %w", err)
+	}
+
+	// Reset metrics
+	collector.cachedMetrics = []prometheus.Metric{}
+
+	crmStats, err := redisClient.HgetAllFromDb(ctx, "COUNTERS_DB", "CRM:STATS")
+	if err != nil {
+		return fmt.Errorf("redis read failed: %w", err)
+	}
+
+	err = collector.collectCrmStatsCounters(ctx, crmStats)
+	if err != nil {
+		return fmt.Errorf("crm stats collection failed: %w", err)
+	}
+
+	level.Info(collector.logger).Log("msg", "Ending crm metric scrape")
+	collector.lastScrapeTime = time.Now()
+	collector.cachedMetrics = append(collector.cachedMetrics, prometheus.MustNewConstMetric(
+		collector.scrapeDuration, prometheus.GaugeValue, time.Since(scrapeTime).Seconds(),
+	))
+	return nil
+}
+
+func (collector *crmCollector) collectCrmStatsCounters(ctx context.Context, crmStats map[string]string) error {
+	for stat, value := range crmStats {
+		parsedValue, err := parseFloat(value)
+		if err != nil {
+			return fmt.Errorf("value parse failed: %w", err)
+		}
+
+		if strings.HasSuffix(stat, "available") {
+			label := strings.TrimSuffix(strings.TrimPrefix(stat, "crm_stats_"), "_available")
+			collector.cachedMetrics = append(collector.cachedMetrics, prometheus.MustNewConstMetric(
+				collector.crmResourceAvailable, prometheus.GaugeValue, parsedValue, label,
+			))
+		}
+
+		if strings.HasSuffix(stat, "used") {
+			label := strings.TrimSuffix(strings.TrimPrefix(stat, "crm_stats_"), "_used")
+			collector.cachedMetrics = append(collector.cachedMetrics, prometheus.MustNewConstMetric(
+				collector.crmResourceUsed, prometheus.GaugeValue, parsedValue, label,
+			))
+		}
+	}
+
+	return nil
+}

--- a/internal/collector/hw_collector.go
+++ b/internal/collector/hw_collector.go
@@ -130,6 +130,8 @@ func (collector *hwCollector) scrapeMetrics(ctx context.Context) error {
 		return fmt.Errorf("redis client initialization failed: %w", err)
 	}
 
+	defer redisClient.Close()
+
 	// Reset metrics
 	collector.cachedMetrics = []prometheus.Metric{}
 

--- a/internal/collector/interface_collector.go
+++ b/internal/collector/interface_collector.go
@@ -134,6 +134,8 @@ func (collector *interfaceCollector) scrapeMetrics(ctx context.Context) error {
 		return fmt.Errorf("redis client initialization failed: %w", err)
 	}
 
+	defer redisClient.Close()
+
 	// Reset metrics
 	collector.cachedMetrics = []prometheus.Metric{}
 

--- a/pkg/redis/client.go
+++ b/pkg/redis/client.go
@@ -119,3 +119,10 @@ func (c Client) KeysFromDb(ctx context.Context, dbName, pattern string) ([]strin
 
 	return keys, err
 }
+
+func (c Client) Close() {
+	for name, client := range c.databases {
+		client.Close()
+		delete(c.databases, name)
+	}
+}


### PR DESCRIPTION
Add a collector for Critical Resource Monitoring metrics.

For now, it just iterates over `CRM:STATS` key in `COUNTERS_DB` and collects all the available stats.
Based on the Redis key name it selects the label and which metric it belongs to.

@vinted/sre-foundations 